### PR TITLE
Groups Resource Updates

### DIFF
--- a/backend/src/groups/dto/add-participant.dto.ts
+++ b/backend/src/groups/dto/add-participant.dto.ts
@@ -1,13 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
 
 export class AddParticipantDto {
   @ApiProperty({
     description: 'User ID of the participant to add to the group',
-    example: '66fda1d3b7d6cad62891f0f9',
+    example: ['66f1ae4732de067c7ba5a873', '66f1ae4732de067c7ba5a874'],
   })
-  @IsString()
-  userId: string;
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  participantIds: string[];
 
   @ApiProperty({
     description:

--- a/backend/src/groups/dto/create-group.dto.ts
+++ b/backend/src/groups/dto/create-group.dto.ts
@@ -9,14 +9,6 @@ import {
 
 export class CreateGroupDto {
   @ApiProperty({
-    description: 'User ID of the user that created the group',
-    example: '66fda1d3b7d6cad62891f0f9',
-  })
-  @IsString()
-  @IsNotEmpty()
-  userId: string;
-
-  @ApiProperty({
     description: 'Name of the group',
     example: 'Weekend Trip',
   })

--- a/backend/src/groups/dto/remove-participant.dto.ts
+++ b/backend/src/groups/dto/remove-participant.dto.ts
@@ -1,13 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
 
 export class RemoveParticipantDto {
   @ApiProperty({
     description: 'User ID of the participant to remove from the group',
-    example: '66f1ae4732de067c7ba5a873',
+    example: ['66f1ae4732de067c7ba5a873', '66f1ae4732de067c7ba5a874'],
   })
-  @IsString()
-  userId: string;
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  participantIds: string[];
 
   @ApiProperty({
     description: 'Group ID of the group to remove the participant from',

--- a/backend/src/groups/dto/update-participant-weight.dto.ts
+++ b/backend/src/groups/dto/update-participant-weight.dto.ts
@@ -7,7 +7,7 @@ export class UpdateParticipantWeightDto {
     example: '66fda1d3b7d6cad62891f0f9',
   })
   @IsString()
-  userId: string;
+  participantId: string;
 
   @ApiProperty({
     description:

--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -6,7 +6,10 @@ import {
   Delete,
   Param,
   Body,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
@@ -14,75 +17,103 @@ import { AddParticipantDto } from './dto/add-participant.dto';
 import { RemoveParticipantDto } from './dto/remove-participant.dto';
 import { UpdateParticipantWeightDto } from './dto/update-participant-weight.dto';
 import { Group } from './schemas/group.schema';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+@ApiTags('groups')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('groups')
 export class GroupsController {
   constructor(private readonly groupService: GroupsService) {}
 
-  // Create a new group
+  @ApiOperation({
+    summary: 'Create a new group',
+    description:
+      'When creating a group, the user needs to set the name of group, the budget for the group, and an optional decription of the group.',
+  })
   @Post()
-  async createGroup(@Body() createGroupDto: CreateGroupDto): Promise<Group> {
-    return this.groupService.createGroup(createGroupDto);
+  async createGroup(
+    @Req() req,
+    @Body() createGroupDto: CreateGroupDto,
+  ): Promise<Group> {
+    return this.groupService.createGroup(req.user._id, createGroupDto);
   }
 
-  // Get all groups
+  @ApiOperation({ summary: 'Get all groups' })
   @Get()
   async getAllGroups(): Promise<Group[]> {
     return this.groupService.getAllGroups();
   }
 
-  // Get all groups for a specific user
-  @Get('/user/:userId')
-  async getAllGroupsForUser(@Param('userId') userId: string): Promise<Group[]> {
-    return this.groupService.getAllGroupsForUser(userId);
+  @ApiOperation({
+    summary: 'Get all groups for a user',
+    description:
+      'This route retrieves all group documents for the logged-in user.',
+  })
+  @Get('/by-user')
+  async getAllGroupsForUser(@Req() req): Promise<Group[]> {
+    return this.groupService.getAllGroupsForUser(req.user._id);
   }
 
-  // Get a specific group by ID
+  @ApiOperation({ summary: 'Get a group via its id' })
   @Get(':groupId')
   async getGroupById(@Param('groupId') groupId: string): Promise<Group> {
     return this.groupService.getGroupById(groupId);
   }
 
-  // Update a group
+  @ApiOperation({
+    summary: 'Update a group via its id',
+    description:
+      "Group's name, decription, or budget can be updated. All fields are optional",
+  })
   @Patch(':groupId')
   async updateGroup(
+    @Req() req,
     @Body() updateGroupDto: UpdateGroupDto,
     @Param('groupId') groupId: string,
   ): Promise<Group> {
-    return this.groupService.updateGroup(updateGroupDto, groupId);
+    return this.groupService.updateGroup(req.user._id, updateGroupDto, groupId);
   }
 
-  // Delete a group
+  @ApiOperation({ summary: 'Delete a group via its id' })
   @Delete(':groupId')
   async deleteGroup(
+    @Req() req,
     @Param('groupId') groupId: string,
   ): Promise<{ message: string }> {
-    return this.groupService.deleteGroup(groupId);
+    return this.groupService.deleteGroup(req.user._id, groupId);
   }
 
-  // Add a participant to a group
+  @ApiOperation({ summary: 'Add participants to a group' })
   @Post('add-participant')
   async addParticipant(
+    @Req() req,
     @Body() addParticipantDto: AddParticipantDto,
   ): Promise<Group> {
-    return this.groupService.addParticipant(addParticipantDto);
+    return this.groupService.addParticipant(req.user._id, addParticipantDto);
   }
 
-  // Remove a participant from a group
+  @ApiOperation({ summary: 'Remove participants from a group' })
   @Post('remove-participant')
   async removeParticipant(
+    @Req() req,
     @Body() removeParticipantDto: RemoveParticipantDto,
   ): Promise<Group> {
-    return this.groupService.removeParticipant(removeParticipantDto);
+    return this.groupService.removeParticipant(
+      req.user._id,
+      removeParticipantDto,
+    );
   }
 
-  // Update a participant's contribution weight in a group
+  @ApiOperation({ summary: "Update a participant's contribution weight" })
   @Patch('update-weight/:groupId')
   async updateParticipantWeight(
+    @Req() req,
     @Param('groupId') groupId: string,
     @Body() updateParticipantWeightDto: UpdateParticipantWeightDto,
   ): Promise<Group> {
     return this.groupService.updateParticipantWeight(
+      req.user._id,
       groupId,
       updateParticipantWeightDto,
     );


### PR DESCRIPTION
This pull request updates the Groups resource to incorporate auth guards, and enhanced service logic.

- All groups controllers are now protected using the JWT auth guard from the auth resource. This means that a user must be logged in to access ```/groups``` routes. To test in Swagger, log in using the ```/auth/login``` route, copy the token, and use this token to login via the Authorize button at the top of the Swagger interface. If testing/using these routes manually, the token must be passed as a BEARER token in the header.
- All groups controllers will utilize the jwt, passed as a BEARER token in the header of a request, to retrieve the user's id. This means that the user no longer has to manually pass their user id (or other user data) within the request body or as a query parameter.
- Relevant routes now perform a check to ensure the user is a participant of a group before they are allowed to make changes to that group.
- The POST ```/groups/add-participant``` and POST ``/groups/remove-participant``` routes now ask for an array of participant (user) ids to be passed in the request body to allow for multiple participants to be added/removed in one request.
- The GET ```/groups/user?userId``` route has been changed to GET ```/groups/by-user``` and retrieves all group documents for the logged-in user.
- All DTOS and Swagger documentation have been updated accordingly.